### PR TITLE
add fn to return 32 random bytes as per the draft

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ hkdf = "0.8.0"
 #pairing-plus = { path = "../../pairing-plus" }
 pairing-plus = "0.19"
 sha2 = "0.8.0"
+ring = "0.16.20"
 
 [dev-dependencies]
 byteorder = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,10 +21,11 @@ extern crate pairing_plus;
 #[cfg(test)]
 extern crate rand;
 extern crate sha2;
+extern crate ring;
 
 mod signature;
 
-pub use signature::{BLSSigCore, BLSSignatureAug, BLSSignatureBasic, BLSSignaturePop};
+pub use signature::{BLSSigCore, BLSSignatureAug, BLSSignatureBasic, BLSSignaturePop, get_rnd_vec};
 
 #[cfg(test)]
 mod test;


### PR DESCRIPTION
Key gen requires at least 32 rnd bytes as per draft (not yet RFC as of now). Add a fn to do so in a secure way.